### PR TITLE
1.21 functionality for minecraft recipes

### DIFF
--- a/data/minecraft/recipe/diamond_boots.json
+++ b/data/minecraft/recipe/diamond_boots.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:diamond"
+    },
+    "Y": {
+      "item": "minecraft:leather_boots"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:diamond_boots"
+  }
+}

--- a/data/minecraft/recipe/diamond_chestplate.json
+++ b/data/minecraft/recipe/diamond_chestplate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:diamond"
+    },
+    "Y": {
+      "item": "minecraft:leather_chestplate"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "XXX",
+    "XXX"
+  ],
+  "result": {
+    "id": "minecraft:diamond_chestplate"
+  }
+}

--- a/data/minecraft/recipe/diamond_helmet.json
+++ b/data/minecraft/recipe/diamond_helmet.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:diamond"
+    },
+    "Y": {
+      "item": "minecraft:leather_helmet"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX"
+  ],
+  "result": {
+    "id": "minecraft:diamond_helmet"
+  }
+}

--- a/data/minecraft/recipe/diamond_leggings.json
+++ b/data/minecraft/recipe/diamond_leggings.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:diamond"
+    },
+    "Y": {
+      "item": "minecraft:leather_leggings"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:diamond_leggings"
+  }
+}

--- a/data/minecraft/recipe/golden_boots.json
+++ b/data/minecraft/recipe/golden_boots.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:gold_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_boots"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:golden_boots"
+  }
+}

--- a/data/minecraft/recipe/golden_chestplate.json
+++ b/data/minecraft/recipe/golden_chestplate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:gold_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_chestplate"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "XXX",
+    "XXX"
+  ],
+  "result": {
+    "id": "minecraft:golden_chestplate"
+  }
+}

--- a/data/minecraft/recipe/golden_helmet.json
+++ b/data/minecraft/recipe/golden_helmet.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:gold_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_helmet"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX"
+  ],
+  "result": {
+    "id": "minecraft:golden_helmet"
+  }
+}

--- a/data/minecraft/recipe/golden_leggings.json
+++ b/data/minecraft/recipe/golden_leggings.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:gold_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_leggings"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:golden_leggings"
+  }
+}

--- a/data/minecraft/recipe/iron_boots.json
+++ b/data/minecraft/recipe/iron_boots.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:iron_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_boots"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:iron_boots"
+  }
+}

--- a/data/minecraft/recipe/iron_chestplate.json
+++ b/data/minecraft/recipe/iron_chestplate.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:iron_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_chestplate"
+    }
+  },
+  "pattern": [
+    "XYX",
+    "XXX",
+    "XXX"
+  ],
+  "result": {
+    "id": "minecraft:iron_chestplate"
+  }
+}

--- a/data/minecraft/recipe/iron_helmet.json
+++ b/data/minecraft/recipe/iron_helmet.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:iron_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_helmet"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX"
+  ],
+  "result": {
+    "id": "minecraft:iron_helmet"
+  }
+}

--- a/data/minecraft/recipe/iron_leggings.json
+++ b/data/minecraft/recipe/iron_leggings.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:iron_ingot"
+    },
+    "Y": {
+      "item": "minecraft:leather_leggings"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX",
+    "X X"
+  ],
+  "result": {
+    "id": "minecraft:iron_leggings"
+  }
+}

--- a/data/minecraft/recipe/turtle_helmet.json
+++ b/data/minecraft/recipe/turtle_helmet.json
@@ -1,0 +1,19 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "category": "equipment",
+  "key": {
+    "X": {
+      "item": "minecraft:scute"
+    },
+    "Y": {
+      "item": "minecraft:leather_helmet"
+    }
+  },
+  "pattern": [
+    "XXX",
+    "XYX"
+  ],
+  "result": {
+    "id": "minecraft:turtle_helmet"
+  }
+}

--- a/data/minecraft/recipe/turtle_helmet.json
+++ b/data/minecraft/recipe/turtle_helmet.json
@@ -3,7 +3,7 @@
   "category": "equipment",
   "key": {
     "X": {
-      "item": "minecraft:scute"
+      "item": "minecraft:turtle_scute"
     },
     "Y": {
       "item": "minecraft:leather_helmet"

--- a/pack.mcmeta
+++ b/pack.mcmeta
@@ -1,6 +1,7 @@
 {
     "pack": {
         "pack_format": 10,
-        "description": "Concept originally suggested by u/ThirdWorldBoy21 on r/minecraftsuggestions; Datapack created by Havio@Modrinth"
+        "supported_formats": {"min_inclusive": 10, "max_inclusive": 48},
+        "description": "Concept originally suggested by u/ThirdWorldBoy21 on r/minecraftsuggestions; Datapack created by Havio@Modrinth; 1.21 update by meenimc@Modrinth"
     }
 }


### PR DESCRIPTION
This updates only the vanilla recipes. There is no warnings and all vanilla recipes are modified as intended.

I have an update ready for AlexMob and Create recipes as well https://github.com/MeeniMc/slower-armor-progression/tree/alexmob/create/1.21, but the new parser in 1.21 spits out a million errors when you do not have these mods active. 

```
[22:05:16] [Server thread/ERROR] (Minecraft) Parsing error loading recipe alexsmobs:straddle_helmet
com.google.gson.JsonParseException: Unknown registry key in ResourceKey[minecraft:root / minecraft:item]: alexsmobs:straddle_helmet; Map entry 'S' : Failed to parse either. First: Input does not contain a key [fabric:type]: MapLike[{"item":"alexsmobs:straddlite"}]; Second: Failed to parse either. First: Not a json array: {"item":"alexsmobs:straddlite"}; Second: No key tag in MapLike[{"item":"alexsmobs:straddlite"}]; Unknown registry key in ResourceKey[minecraft:root / minecraft:item]: alexsmobs:straddlite
```

If I find an elegant solution I'll cherry-pick these in the PR as well. Otherwise it may be necessary to split this pack into the main, and addon packs for each. 

